### PR TITLE
Fix linker failures on osx

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -3,7 +3,7 @@
         {
             'target_name': 'vad',
             'product_extension': 'node',
-            'type': 'shared_library',
+            'type': 'loadable_module',
             'defines': [],
             'include_dirs': ["<!(node -e \"require('nan')\")", "./src"],
             'sources': [


### PR DESCRIPTION
Fixes #2 - linker failures on OSX.

I followed https://github.com/libxmljs/libxmljs/issues/315 described in https://github.com/libxmljs/libxmljs/commit/c95f43b70410675dc3ae473369387e3275e7594c.

I don't know enough about gyp to know if there are implications for other platforms but thought it was worth raising the PR anyway.